### PR TITLE
Fix github action

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -13,7 +13,7 @@ function run_analyze() {
     exit 1
   fi
 
-  result=$(flutter pub run dart_code_metrics:metrics .)
+  result=$(flutter pub run dart_code_metrics:metrics lib test)
   if [ "$result" != "" ]; then
     echo "flutter dart code metrics issues:"
     echo "$result"

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -13,7 +13,8 @@ function run_analyze() {
     exit 1
   fi
 
-  result=$(flutter pub run dart_code_metrics:metrics lib test)
+  root=$(pwd)
+  result=$(flutter pub run dart_code_metrics:metrics $root)
   if [ "$result" != "" ]; then
     echo "flutter dart code metrics issues:"
     echo "$result"


### PR DESCRIPTION
While browsing the flame src code I noticed several terrible errors popping up every so often, which made it extremely hard to properly read and understand it.

That led me to an investigation and turns out there is a bug in the way we use dart code metrics on all our scripts, most notably on this action.

For some reason, using `.` doesn't work recursively. But using folder names does; see the image attached:

![image](https://user-images.githubusercontent.com/882703/132451206-393b2b6f-a8e7-4fc7-aa5f-15404df511ff.png)

Luckily the fix is simple, even though `.` should work just fine.